### PR TITLE
Bump mainline version to 1.11.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.9.15
+FROM nginx:1.11.1
 MAINTAINER Archie Lee <achi@987.tw>
 
 RUN DEBIAN_FRONTEND=noninteractive \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Supported tags and respective Dockerfile links
 
-- [`latest`](https://github.com/jihchi/docker-nginx-consul/blob/master/Dockerfile), [`1.9.15_0.14.0`](https://github.com/jihchi/docker-nginx-consul/blob/1.9.15_0.14.0/Dockerfile)
+- [`latest`](https://github.com/jihchi/docker-nginx-consul/blob/master/Dockerfile), [`1.11.1_0.14.0`](https://github.com/jihchi/docker-nginx-consul/blob/1.11.1_0.14.0/Dockerfile)
 - [`stable`](https://github.com/jihchi/docker-nginx-consul/blob/stable/Dockerfile), [`1.10.0_0.14.0`](https://github.com/jihchi/docker-nginx-consul/blob/1.10.0_0.14.0/Dockerfile)
 
 # Nginx with Consul Template


### PR DESCRIPTION
This isn't the latest version because library/nginx is out of date, but it's newer than the prior version.
